### PR TITLE
Use ${node_bin} for the node binary

### DIFF
--- a/LSP-graphql.sublime-settings
+++ b/LSP-graphql.sublime-settings
@@ -1,5 +1,5 @@
 {
-	"command": ["node", "${server_path}", "server", "--method", "stream"],
+	"command": ["${node_bin}", "${server_path}", "server", "--method", "stream"],
 	"languages": [
 		{
 			"languageId": "graphql",

--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,4 @@
 import os
-from LSP.plugin.core.typing import Dict, List
 from lsp_utils import NpmClientHandler
 
 
@@ -17,11 +16,3 @@ class LspGraphqlPlugin(NpmClientHandler):
     server_binary_path = os.path.join(
         server_directory, 'node_modules', 'graphql-language-service-cli', 'bin', 'graphql.js'
     )
-
-    @classmethod
-    def get_binary_arguments(cls):
-        return ['server', '--method', 'stream']
-
-    @classmethod
-    def install_in_cache(cls) -> bool:
-        return False


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d